### PR TITLE
Support root-namespace parent classes

### DIFF
--- a/src/PhpParser/NodeVisitor/ParentClassNameCollectingNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/ParentClassNameCollectingNodeVisitor.php
@@ -39,13 +39,13 @@ final class ParentClassNameCollectingNodeVisitor extends NodeVisitorAbstract
         $uniqueParentClassNames = array_unique($this->parentClassNames);
         sort($uniqueParentClassNames);
 
-        // remove native classes
         $namespacedClassNames = [];
         foreach($uniqueParentClassNames as $className) {
             try {
                 // @phpstan-ignore-next-line
                 $reflectionClass = new \ReflectionClass($className);
                 if ($reflectionClass->isInternal()) {
+                    // remove native classes
                     continue;
                 }
                 $namespacedClassNames[] = $className;

--- a/src/PhpParser/NodeVisitor/ParentClassNameCollectingNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/ParentClassNameCollectingNodeVisitor.php
@@ -40,10 +40,19 @@ final class ParentClassNameCollectingNodeVisitor extends NodeVisitorAbstract
         sort($uniqueParentClassNames);
 
         // remove native classes
-        $namespacedClassNames = array_filter(
-            $uniqueParentClassNames,
-            static fn (string $parentClassName): bool => str_contains($parentClassName, '\\')
-        );
+        $namespacedClassNames = [];
+        foreach($uniqueParentClassNames as $className) {
+            try {
+                // @phpstan-ignore-next-line
+                $reflectionClass = new \ReflectionClass($className);
+                if ($reflectionClass->isInternal()) {
+                    continue;
+                }
+                $namespacedClassNames[] = $className;
+            } catch (\ReflectionException $e) {
+                $namespacedClassNames[] = $className;
+            }
+        }
 
         // remove obviously vendor names
         $namespacedClassNames = array_filter($namespacedClassNames, static function (string $className): bool {

--- a/src/PhpParser/NodeVisitor/ParentClassNameCollectingNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/ParentClassNameCollectingNodeVisitor.php
@@ -39,23 +39,8 @@ final class ParentClassNameCollectingNodeVisitor extends NodeVisitorAbstract
         $uniqueParentClassNames = array_unique($this->parentClassNames);
         sort($uniqueParentClassNames);
 
-        $namespacedClassNames = [];
-        foreach($uniqueParentClassNames as $className) {
-            try {
-                // @phpstan-ignore-next-line
-                $reflectionClass = new \ReflectionClass($className);
-                if ($reflectionClass->isInternal()) {
-                    // remove native classes
-                    continue;
-                }
-                $namespacedClassNames[] = $className;
-            } catch (\ReflectionException $e) {
-                $namespacedClassNames[] = $className;
-            }
-        }
-
         // remove obviously vendor names
-        $namespacedClassNames = array_filter($namespacedClassNames, static function (string $className): bool {
+        $namespacedClassNames = array_filter($uniqueParentClassNames, static function (string $className): bool {
             if (str_contains($className, 'Symfony\\')) {
                 return false;
             }

--- a/tests/ParentClassResolver/Fixture/SomeClassWithInternalParent.php
+++ b/tests/ParentClassResolver/Fixture/SomeClassWithInternalParent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SwissKnife\Tests\ParentClassResolver\Fixture;
+
+final class SomeClassWithInternalParent extends \ArrayObject
+{
+}

--- a/tests/ParentClassResolver/Fixture/SomeClassWithParents.php
+++ b/tests/ParentClassResolver/Fixture/SomeClassWithParents.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SwissKnife\Tests\ParentClassResolver\Fixture;
+
+final class SomeClassWithParents extends SomeParentClass
+{
+}

--- a/tests/ParentClassResolver/Fixture/SomeClassWithRootNamespaceParent.php
+++ b/tests/ParentClassResolver/Fixture/SomeClassWithRootNamespaceParent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SwissKnife\Tests\ParentClassResolver\Fixture;
+
+final class SomeClassWithRootNamespaceParent extends \SomeUnknownRootNamespaceClass
+{
+}

--- a/tests/ParentClassResolver/Fixture/SomeClassWithRootNamespaceParent.php
+++ b/tests/ParentClassResolver/Fixture/SomeClassWithRootNamespaceParent.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Rector\SwissKnife\Tests\ParentClassResolver\Fixture;
-
-final class SomeClassWithRootNamespaceParent extends \SomeUnknownRootNamespaceClass
-{
-}

--- a/tests/ParentClassResolver/Fixture/SomeParentClass.php
+++ b/tests/ParentClassResolver/Fixture/SomeParentClass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SwissKnife\Tests\ParentClassResolver\Fixture;
+
+class SomeParentClass
+{
+}

--- a/tests/ParentClassResolver/ParentClassResolverTest.php
+++ b/tests/ParentClassResolver/ParentClassResolverTest.php
@@ -25,8 +25,11 @@ final class ParentClassResolverTest extends AbstractTestCase
 
     public function test(): void
     {
-        $parentClasses = $this->parentClassResolver->resolve(PhpFilesFinder::find([__DIR__ . '/Fixture']), static function (): void {
-        });
+        $parentClasses = $this->parentClassResolver->resolve(
+            PhpFilesFinder::find([__DIR__ . '/Fixture']),
+            static function (): void {
+            }
+        );
 
         $this->assertSame(
             [

--- a/tests/ParentClassResolver/ParentClassResolverTest.php
+++ b/tests/ParentClassResolver/ParentClassResolverTest.php
@@ -7,9 +7,7 @@ namespace Rector\SwissKnife\Tests\ParentClassResolver;
 use Rector\SwissKnife\Finder\PhpFilesFinder;
 use Rector\SwissKnife\ParentClassResolver;
 use Rector\SwissKnife\Tests\AbstractTestCase;
-use Rector\SwissKnife\Tests\ParentClassResolver\Fixture\AbstractParentClass;
-use Rector\SwissKnife\Tests\ParentClassResolver\Fixture\ParentClass;
-use Rector\SwissKnife\Tests\ParentClassResolver\Fixture\ParentClassInSeparateNamespace;
+use Rector\SwissKnife\Tests\ParentClassResolver\Fixture\SomeParentClass;
 
 final class ParentClassResolverTest extends AbstractTestCase
 {
@@ -24,14 +22,17 @@ final class ParentClassResolverTest extends AbstractTestCase
 
     public function test(): void
     {
-        $parentClasses = $this->parentClassResolver->resolve(
-            PhpFilesFinder::find([__DIR__ . '/Fixture']),
-            static function (): void {
-            }
-        );
+        $parentClasses = $this->parentClassResolver->resolve(PhpFilesFinder::find([__DIR__ . '/Fixture']), static function (): void {
+        });
 
         $this->assertSame(
-            [AbstractParentClass::class, ParentClass::class, ParentClassInSeparateNamespace::class],
+            [
+                'Rector\SwissKnife\Tests\ParentClassResolver\Fixture\AbstractParentClass',
+                'Rector\SwissKnife\Tests\ParentClassResolver\Fixture\ParentClass',
+                'Rector\SwissKnife\Tests\ParentClassResolver\Fixture\ParentClassInSeparateNamespace',
+                SomeParentClass::class,
+                \SomeUnknownRootNamespaceClass::class, // @phpstan-ignore-line
+            ],
             $parentClasses
         );
     }

--- a/tests/ParentClassResolver/ParentClassResolverTest.php
+++ b/tests/ParentClassResolver/ParentClassResolverTest.php
@@ -27,6 +27,7 @@ final class ParentClassResolverTest extends AbstractTestCase
 
         $this->assertSame(
             [
+                'ArrayObject',
                 'Rector\SwissKnife\Tests\ParentClassResolver\Fixture\AbstractParentClass',
                 'Rector\SwissKnife\Tests\ParentClassResolver\Fixture\ParentClass',
                 'Rector\SwissKnife\Tests\ParentClassResolver\Fixture\ParentClassInSeparateNamespace',

--- a/tests/ParentClassResolver/ParentClassResolverTest.php
+++ b/tests/ParentClassResolver/ParentClassResolverTest.php
@@ -7,6 +7,9 @@ namespace Rector\SwissKnife\Tests\ParentClassResolver;
 use Rector\SwissKnife\Finder\PhpFilesFinder;
 use Rector\SwissKnife\ParentClassResolver;
 use Rector\SwissKnife\Tests\AbstractTestCase;
+use Rector\SwissKnife\Tests\ParentClassResolver\Fixture\AbstractParentClass;
+use Rector\SwissKnife\Tests\ParentClassResolver\Fixture\ParentClass;
+use Rector\SwissKnife\Tests\ParentClassResolver\Fixture\ParentClassInSeparateNamespace;
 use Rector\SwissKnife\Tests\ParentClassResolver\Fixture\SomeParentClass;
 
 final class ParentClassResolverTest extends AbstractTestCase
@@ -28,9 +31,9 @@ final class ParentClassResolverTest extends AbstractTestCase
         $this->assertSame(
             [
                 'ArrayObject',
-                'Rector\SwissKnife\Tests\ParentClassResolver\Fixture\AbstractParentClass',
-                'Rector\SwissKnife\Tests\ParentClassResolver\Fixture\ParentClass',
-                'Rector\SwissKnife\Tests\ParentClassResolver\Fixture\ParentClassInSeparateNamespace',
+                AbstractParentClass::class,
+                ParentClass::class,
+                ParentClassInSeparateNamespace::class,
                 SomeParentClass::class,
                 \SomeUnknownRootNamespaceClass::class, // @phpstan-ignore-line
             ],

--- a/tests/ParentClassResolver/ParentClassResolverTest.php
+++ b/tests/ParentClassResolver/ParentClassResolverTest.php
@@ -35,7 +35,6 @@ final class ParentClassResolverTest extends AbstractTestCase
                 ParentClass::class,
                 ParentClassInSeparateNamespace::class,
                 SomeParentClass::class,
-                \SomeUnknownRootNamespaceClass::class, // @phpstan-ignore-line
             ],
             $parentClasses
         );


### PR DESCRIPTION
before this PR, base-classes without a namespace were not properly detected

(they were skipped, as they were mistakenly detected as a php-src native class)