### PR TITLE
[Comments] Handle new line mix betweeen \n and \r\n in the code on CommentedCodeAnalyzer

### DIFF
--- a/src/Comments/CommentedCodeAnalyzer.php
+++ b/src/Comments/CommentedCodeAnalyzer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Rector\SwissKnife\Comments;
 
 use Nette\Utils\FileSystem;
+use Nette\Utils\Strings;
 
 /**
  * @see \Rector\SwissKnife\Tests\Comments\CommentedCodeAnalyzerTest
@@ -12,13 +13,20 @@ use Nette\Utils\FileSystem;
 final class CommentedCodeAnalyzer
 {
     /**
+     * @var string
+     * @see https://regex101.com/r/5OlGjG/1
+     * @see https://3v4l.org/Y8pSD
+     */
+    private const NEWLINE_REGEX = '#\r?\n#';
+
+    /**
      * @return int[]
      */
     public function process(string $filePath, int $commentedLinesCountLimit): array
     {
         $commentedLines = [];
 
-        $fileLines = explode(PHP_EOL, FileSystem::read($filePath));
+        $fileLines = Strings::split(FileSystem::read($filePath), self::NEWLINE_REGEX);
 
         $commentLinesCount = 0;
 


### PR DESCRIPTION
when code is generated code or being read by some tool may cause multiple different line endings, so can't rely on `PHP_EOL`, use `\r?\n` regex instead,

see https://3v4l.org/Y8pSD

The behaviour is same with Rector's `NewLineSplitter` https://github.com/rectorphp/rector-src/blob/a16a04d0bc90df11918efd4b7fc117a9e3dcc1c3/src/Util/NewLineSplitter.php#L15-L23