### PR TITLE
Accept unfinalized readonly classes

### DIFF
--- a/src/Command/FinalizeClassesCommand.php
+++ b/src/Command/FinalizeClassesCommand.php
@@ -25,7 +25,7 @@ final class FinalizeClassesCommand extends Command
     /**
      * @see https://regex101.com/r/Q5Nfbo/1
      */
-    private const NEWLINE_CLASS_START_REGEX = '#^class\s#m';
+    private const NEWLINE_CLASS_START_REGEX = '#^(readonly )?class\s#m';
 
     public function __construct(
         private readonly SymfonyStyle $symfonyStyle,
@@ -118,7 +118,7 @@ final class FinalizeClassesCommand extends Command
             $finalizedContents = Strings::replace(
                 $phpFileInfo->getContents(),
                 self::NEWLINE_CLASS_START_REGEX,
-                'final class '
+                'final $1class '
             );
 
             $finalizedFilePaths[] = PathHelper::relativeToCwd($phpFileInfo->getRealPath());

--- a/tests/NeedsFinalizeAnalyzer/Fixture/non_final_readonly_class.php.inc
+++ b/tests/NeedsFinalizeAnalyzer/Fixture/non_final_readonly_class.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SwissKnife\Tests\NeedsFinalizeAnalyzer\Fixture;
+
+readonly class NonFinalReadonlyClass
+{
+}

--- a/tests/NeedsFinalizeAnalyzer/NeedsFinalizeAnalyzerTest.php
+++ b/tests/NeedsFinalizeAnalyzer/NeedsFinalizeAnalyzerTest.php
@@ -40,5 +40,6 @@ final class NeedsFinalizeAnalyzerTest extends AbstractTestCase
         yield [__DIR__ . '/Fixture/anonymous_class.php.inc', false];
 
         yield [__DIR__ . '/Fixture/non_final_class.php.inc', true];
+        yield [__DIR__ . '/Fixture/non_final_readonly_class.php.inc', true];
     }
 }


### PR DESCRIPTION
I made this pull request to accept readonly classes, for instance this class is detected as non-final by the command but nothing's  changed :

```php
<?php
readonly class MyAwesomeClass {
}
```