### PR TITLE
Provide better error message after syntax error

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -5,6 +5,10 @@ declare(strict_types=1);
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return ECSConfig::configure()
+    ->withSkip([
+        // invalid syntax test fixture
+        __DIR__ . '/tests/PhpParser/Finder/ClassConstantFetchFinder/Fixture/Error/ParseError.php',
+    ])
     ->withPreparedSets(psr12: true, common: true, symplify: true)
     ->withPaths([__DIR__ . '/src', __DIR__ . '/tests'])
     ->withRootFiles();

--- a/src/PhpParser/CachedPhpParser.php
+++ b/src/PhpParser/CachedPhpParser.php
@@ -34,7 +34,15 @@ final class CachedPhpParser
         }
 
         $fileContents = FileSystem::read($filePath);
-        $stmts = $this->phpParser->parse($fileContents);
+        try {
+            $stmts = $this->phpParser->parse($fileContents);
+        } catch (\Throwable $throwable) {
+            throw new \RuntimeException(sprintf(
+                'Could not parse file "%s": %s',
+                $filePath,
+                $throwable->getMessage()
+            ), $throwable->getCode(), $throwable);
+        }
 
         if (is_array($stmts)) {
             $nodeTraverser = NodeTraverserFactory::create(new NameResolver());

--- a/tests/PhpParser/Finder/ClassConstantFetchFinder/ClassConstantFetchFinderTest.php
+++ b/tests/PhpParser/Finder/ClassConstantFetchFinder/ClassConstantFetchFinderTest.php
@@ -42,6 +42,19 @@ final class ClassConstantFetchFinderTest extends AbstractTestCase
         $this->assertInstanceOf(ExternalClassAccessConstantFetch::class, $secondClassConstantFetch);
     }
 
+    public function testParseError(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Could not parse file "' . __DIR__ . '/Fixture/Error/ParseError.php": Syntax error, unexpected T_STRING on line 6'
+        );
+
+        $directory = __DIR__ . '/Fixture/Error';
+        $progressBar = new ProgressBar(new NullOutput());
+        $fileInfos = PhpFilesFinder::find([$directory]);
+        $this->classConstantsFetchFinder->find($fileInfos, $progressBar, false);
+    }
+
     /**
      * @return ClassConstantFetchInterface[]
      */

--- a/tests/PhpParser/Finder/ClassConstantFetchFinder/Fixture/Error/ParseError.php
+++ b/tests/PhpParser/Finder/ClassConstantFetchFinder/Fixture/Error/ParseError.php
@@ -1,0 +1,7 @@
+<?php
+namespace ParseError;
+
+function doFoo() {
+    // this file intentionally contains this parse error
+    $x ABC
+}


### PR DESCRIPTION
same problem as in https://github.com/TomasVotruba/class-leak/issues/45