### PR TITLE
Support `createPartialMock`

### DIFF
--- a/src/PhpParser/NodeVisitor/MockedClassNameCollectingNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/MockedClassNameCollectingNodeVisitor.php
@@ -32,7 +32,14 @@ final class MockedClassNameCollectingNodeVisitor extends NodeVisitorAbstract
         }
 
         $methodName = $node->name->toString();
-        if (! in_array($methodName, ['getMock', 'createMock', 'mock', 'getMockBuilder'], true)) {
+        $mockMethodNames = [
+            'createMock',
+            'createPartialMock',
+            'getMock',
+            'getMockBuilder',
+            'mock',
+        ];
+        if (! in_array($methodName, $mockMethodNames, true)) {
             return null;
         }
 


### PR DESCRIPTION
adds `createPartialMock` to the recognized mock-methods like:
- https://github.com/rectorphp/swiss-knife/pull/37
- https://github.com/rectorphp/swiss-knife/pull/38

```php
$mock = $this->createPartialMock(Foo::class, ['bar']);
```