### PR TITLE
Fix patch header not to require new file

### DIFF
--- a/patches/symfony-console-helper-helper-php.patch
+++ b/patches/symfony-console-helper-helper-php.patch
@@ -1,4 +1,4 @@
---- /dev/null
+--- ../Helper/Helper.php~
 +++ ../Helper/Helper.php
 @@ -47,9 +47,9 @@
      {


### PR DESCRIPTION
Avoids error that patch thinks file needs to be created, but it already exists.

Fixes https://github.com/rectorphp/swiss-knife/issues/89