### PR TITLE
[Scoper] Exclude DateRangeError on scoper.php to be skipped as native PHP 8.3+ class

### DIFF
--- a/scoper.php
+++ b/scoper.php
@@ -13,6 +13,11 @@ use Nette\Utils\Strings;
 // see https://github.com/humbug/php-scoper
 return [
     'prefix' => 'SwissKnife' . $timestamp,
+    // exclude
+    'exclude-classes' => [
+        // native class on php 8.3+
+        'DateRangeError',
+    ],
     'expose-constants' => ['#^SYMFONY\_[\p{L}_]+$#'],
     'exclude-namespaces' => [
         '#^Rector\\\\SwissKnife#',


### PR DESCRIPTION
On scoping, it currently scoped as:

```php
\SwissKnife202508\DateRangeError
```

see

https://github.com/rectorphp/swiss-knife/blob/4e19741422511b7b26d64dcf272fab6dc155f873/vendor/symfony/yaml/Inline.php#L675

which should be keep as `\DateRangeError`.

This similar with what rector have, see PR:

- https://github.com/rectorphp/rector-src/pull/7027

we currently use `humbug/php-scoper` 0.18.11, so we may need to cross check latest `0.18.17` if it already cover this later ;)