### PR TITLE
Ignore node_modules in check-conflicts

### DIFF
--- a/src/Finder/FilesFinder.php
+++ b/src/Finder/FilesFinder.php
@@ -25,6 +25,7 @@ final class FilesFinder
             ->files()
             ->in($paths)
             // not our code
+            ->notPath('node_modules')
             ->notPath('vendor')
             ->notPath('var/cache')
             ->sortByName();


### PR DESCRIPTION
I believe most PHP webapp monorepos are paired with a `node_modules` directory, so having this included in the `check-conflicts` command can significantly slow it down. As there's no way to pass through directories to exclude as options, I feel it's sensible to include as a default behaviour.

Here's the results on a pretty average app with/without this change:

With node_modules:
> [OK] No conflicts found in 25686 files
> 7.5s total time taken

Without node_modules:
> [OK] No conflicts found in 8818 files
> 1.4s total time taken