### PR TITLE
Keep file permission on FileSystem::write() with pass null on 3rd arg

### DIFF
--- a/src/Command/AliceYamlFixturesToPhpCommand.php
+++ b/src/Command/AliceYamlFixturesToPhpCommand.php
@@ -61,7 +61,7 @@ final class AliceYamlFixturesToPhpCommand extends Command
                 $phpFilePath = substr($yamlFileInfo->getRealPath(), 0, -5) . '.php';
             }
 
-            FileSystem::write($phpFilePath, $phpFileContents);
+            FileSystem::write($phpFilePath, $phpFileContents, null);
 
             // remove YAML file
             unlink($yamlFileInfo->getRealPath());

--- a/src/Command/FinalizeClassesCommand.php
+++ b/src/Command/FinalizeClassesCommand.php
@@ -143,7 +143,7 @@ final class FinalizeClassesCommand extends Command
             $finalizedFilePaths[] = PathHelper::relativeToCwd($phpFileInfo->getRealPath());
 
             if ($isDryRun === false) {
-                FileSystem::write($phpFileInfo->getRealPath(), $finalizedContents);
+                FileSystem::write($phpFileInfo->getRealPath(), $finalizedContents, null);
             }
         }
 

--- a/src/Command/NamespaceToPSR4Command.php
+++ b/src/Command/NamespaceToPSR4Command.php
@@ -82,7 +82,7 @@ final class NamespaceToPSR4Command extends Command
             );
 
             // 4. print file
-            FileSystem::write($fileInfo->getRealPath(), $correctedContents);
+            FileSystem::write($fileInfo->getRealPath(), $correctedContents, null);
 
             ++$changedFilesCount;
         }

--- a/src/Command/PrettyJsonCommand.php
+++ b/src/Command/PrettyJsonCommand.php
@@ -75,7 +75,7 @@ final class PrettyJsonCommand extends Command
             }
 
             $prettyJsonContent = Json::encode(Json::decode($jsonContent), JSON_PRETTY_PRINT);
-            FileSystem::write($jsonFileInfo->getRealPath(), $prettyJsonContent);
+            FileSystem::write($jsonFileInfo->getRealPath(), $prettyJsonContent, null);
         }
 
         $successMessage = sprintf(

--- a/src/Command/PrivatizeConstantsCommand.php
+++ b/src/Command/PrivatizeConstantsCommand.php
@@ -143,7 +143,7 @@ final class PrivatizeConstantsCommand extends Command
                 '#((private|public|protected)\s+)?const\s+' . $classConstant->getConstantName() . '#',
                 'private const ' . $classConstant->getConstantName()
             );
-            FileSystem::write($phpFileInfo->getRealPath(), $changedFileContents);
+            FileSystem::write($phpFileInfo->getRealPath(), $changedFileContents, null);
 
             $this->symfonyStyle->writeln(
                 sprintf('Constant "%s" changed to private', $classConstant->getConstantName())

--- a/src/Command/SplitSymfonyConfigToPerPackageCommand.php
+++ b/src/Command/SplitSymfonyConfigToPerPackageCommand.php
@@ -78,7 +78,7 @@ final class SplitSymfonyConfigToPerPackageCommand extends Command
 
             $splitConfigFilePath = $outputDir . '/' . $extensionNameString->value . '.php';
 
-            FileSystem::write($splitConfigFilePath, $splitConfigFileContents);
+            ($splitConfigFilePath, $splitConfigFileContents);
         }
 
         // load packages from the output dir
@@ -88,7 +88,7 @@ final class SplitSymfonyConfigToPerPackageCommand extends Command
 
         // @todo print config back :)
         $cleanedConfigContents = $this->printerStandard->prettyPrintFile($stmts);
-        FileSystem::write($configPath, $cleanedConfigContents);
+        FileSystem::write($configPath, $cleanedConfigContents, null);
 
         return 0;
     }

--- a/src/Command/SplitSymfonyConfigToPerPackageCommand.php
+++ b/src/Command/SplitSymfonyConfigToPerPackageCommand.php
@@ -78,7 +78,7 @@ final class SplitSymfonyConfigToPerPackageCommand extends Command
 
             $splitConfigFilePath = $outputDir . '/' . $extensionNameString->value . '.php';
 
-            ($splitConfigFilePath, $splitConfigFileContents);
+            FileSystem::write($splitConfigFilePath, $splitConfigFileContents, null);
         }
 
         // load packages from the output dir

--- a/src/Testing/Command/DetectUnitTestsCommand.php
+++ b/src/Testing/Command/DetectUnitTestsCommand.php
@@ -57,7 +57,7 @@ final class DetectUnitTestsCommand extends Command
 
         $filesPHPUnitXmlContents = $this->phpunitXmlPrinter->printFiles($unitTestCasesClassesToFilePaths);
 
-        FileSystem::write(self::OUTPUT_FILENAME, $filesPHPUnitXmlContents);
+        FileSystem::write(self::OUTPUT_FILENAME, $filesPHPUnitXmlContents, null);
 
         $successMessage = sprintf(
             'List of %d unit tests was dumped into "%s"',


### PR DESCRIPTION
see due default value is not null, so it changed the original.

https://github.com/nette/utils/blob/8ee89b19f7a1adcaa59c4aaaf6b5525588a40d4e/src/Utils/FileSystem.php#L214-L225