### PR TITLE
fix: [namespace-to-psr-4] Incorrect namespace due to casting error (fixes rectorphp/swiss-knife#124)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     ],
     "require": {
         "php": ">=8.3",
-        "entropy/entropy": "^0.2.1",
+        "entropy/entropy": "^0.2.2",
         "nette/robot-loader": "^4.1",
         "nette/utils": "^4.1",
         "nikic/php-parser": "^5.7",

--- a/tests/Command/NamespaceToPSR4CommandTest.php
+++ b/tests/Command/NamespaceToPSR4CommandTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\SwissKnife\Tests\Command;
+
+use Entropy\Console\Mapper\CLIRequestMapper;
+use Entropy\Console\ValueObject\CLIRequest;
+use Rector\SwissKnife\Command\NamespaceToPSR4Command;
+use Rector\SwissKnife\Tests\AbstractTestCase;
+
+final class NamespaceToPSR4CommandTest extends AbstractTestCase
+{
+    private CLIRequestMapper $cliRequestMapper;
+
+    private NamespaceToPSR4Command $namespaceToPSR4Command;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cliRequestMapper = $this->make(CLIRequestMapper::class);
+        $this->namespaceToPSR4Command = $this->make(NamespaceToPSR4Command::class);
+    }
+
+    /**
+     * @see https://github.com/rectorphp/swiss-knife/issues/124
+     */
+    public function testNamespaceRootOptionIsKeptAsString(): void
+    {
+        // the input parser collects long-option values into arrays;
+        // the string parameter must receive the single value, not the array cast to "Array"
+        $cliRequest = new CLIRequest('namespace-to-psr-4', ['app'], [
+            'namespace-root' => ['App\\'],
+        ]);
+
+        $arguments = $this->cliRequestMapper->resolveArguments($this->namespaceToPSR4Command, $cliRequest);
+
+        $this->assertSame(['app', 'App\\'], $arguments);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes rectorphp/swiss-knife#124 — [namespace-to-psr-4] Incorrect namespace due to casting error

## Root cause
See the commit message and diff for details of what was changed and why.

## Testing
- Test suite was run locally — see commit for details.

> Opened automatically by bin/maintainer.php. Please review carefully before merging.