### PR TITLE
Define PHP 7.4 token constants for downgraded build

### DIFF
--- a/bin/swiss-knife.php
+++ b/bin/swiss-knife.php
@@ -27,6 +27,19 @@ foreach ($possibleAutoloadPaths as $possibleAutoloadPath) {
     }
 }
 
+// the released tool is downgraded to PHP 7.2, but the bundled nikic/php-parser
+// references PHP 7.4 token constants directly - define them to avoid fatal errors
+// (see https://github.com/easy-coding-standard/ecs/blob/main/bin/ecs.php for the same approach)
+if (! defined('T_FN')) {
+    define('T_FN', 5025);
+}
+if (! defined('T_COALESCE_EQUAL')) {
+    define('T_COALESCE_EQUAL', 5030);
+}
+if (! defined('T_BAD_CHARACTER')) {
+    define('T_BAD_CHARACTER', 5035);
+}
+
 $containerFactory = new ContainerFactory();
 $container = $containerFactory->create();
 


### PR DESCRIPTION
## Problem

The released tool is downgraded to **PHP 7.2**, but the bundled `nikic/php-parser` references PHP **7.4** token constants directly. On a real 7.2 runtime this fatals on boot:

```
PHP Fatal error: Uncaught Error: Undefined constant 'T_BAD_CHARACTER'
  in vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php:155
```

(plus `constant(): Couldn't find constant T_FN` / `T_COALESCE_EQUAL` warnings)

php-parser ships `compatibility_tokens.php`, but it only polyfills PHP **8.0+** tokens — the 7.4 ones (`T_FN`, `T_COALESCE_EQUAL`, `T_BAD_CHARACTER`) are assumed to always exist, which is not true once the tool is downgraded to 7.2.

## Fix

Define the three missing 7.4 token constants in the bin entry point, guarded by `defined()` so it is a no-op on PHP 7.4+. Same approach ECS uses in [`bin/ecs.php`](https://github.com/easy-coding-standard/ecs/blob/main/bin/ecs.php).

## Verification

Ran the patched build on a real PHP 7.2.34 against a project — previously fatal, now:

```
[OK] No conflicts found in 17130 files
```