### PR TITLE
 Allow symfony/console ^6.4|^7.0|^8.0 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "nette/robot-loader": "^4.1",
         "nette/utils": "^4.1",
         "nikic/php-parser": "^5.7",
-        "symfony/console": "^6.4.24|^7.4|^8.0",
+        "symfony/console": "^6.4.24|^7.0|^8.0",
         "symfony/finder": "^7.4|^8.0",
         "symfony/yaml": "^7.4|^8.0",
         "webmozart/assert": "^2.4"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "nette/robot-loader": "^4.1",
         "nette/utils": "^4.1",
         "nikic/php-parser": "^5.7",
-        "symfony/console": "^6.4.24",
+        "symfony/console": "^6.4.24|^7.4|^8.0",
         "symfony/finder": "^7.4|^8.0",
         "symfony/yaml": "^7.4|^8.0",
         "webmozart/assert": "^2.4"


### PR DESCRIPTION
Fixes https://github.com/rectorphp/swiss-knife/issues/128

This reproduced at getrector.com repo which can't upgrade to latest swiss-knife 2.4.5

```
➜  getrector-com git:(automated-regenerated-composer-lock) composer update  rector/swiss-knife:^2.4.5                                  
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires rector/swiss-knife ^2.4.5 -> satisfiable by rector/swiss-knife[2.4.5].
    - Root composer.json requires symfony/yaml ^8.1 -> satisfiable by symfony/yaml[v8.1.0].
    - rector/swiss-knife 2.4.5 requires symfony/console ^6.4.24 -> satisfiable by symfony/console[v6.4.24, ..., v6.4.41].
    - symfony/yaml v8.1.0 conflicts with symfony/console v6.4.41.
 ```