### PR TITLE
Fix #128: remove symfony/console dependency by adopting Entropy

### DIFF
--- a/bin/swiss-knife.php
+++ b/bin/swiss-knife.php
@@ -33,9 +33,11 @@ foreach ($possibleAutoloadPaths as $possibleAutoloadPath) {
 if (! defined('T_FN')) {
     define('T_FN', 5025);
 }
+
 if (! defined('T_COALESCE_EQUAL')) {
     define('T_COALESCE_EQUAL', 5030);
 }
+
 if (! defined('T_BAD_CHARACTER')) {
     define('T_BAD_CHARACTER', 5035);
 }

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,10 @@
     ],
     "require": {
         "php": ">=8.3",
-        "entropy/entropy": "^0.2.2",
+        "entropy/entropy": "^0.4.0",
         "nette/robot-loader": "^4.1",
         "nette/utils": "^4.1",
         "nikic/php-parser": "^5.7",
-        "symfony/console": "^6.4.24",
         "symfony/finder": "^7.4|^8.0",
         "symfony/yaml": "^7.4|^8.0",
         "webmozart/assert": "^2.4"

--- a/src/Command/AliceYamlFixturesToPhpCommand.php
+++ b/src/Command/AliceYamlFixturesToPhpCommand.php
@@ -6,12 +6,12 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Nette\Utils\FileSystem;
 use PhpParser\BuilderHelpers;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\PrettyPrinter\Standard;
 use Rector\SwissKnife\Finder\FilesFinder;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -20,7 +20,7 @@ use Symfony\Component\Yaml\Yaml;
 final readonly class AliceYamlFixturesToPhpCommand implements CommandInterface
 {
     public function __construct(
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
     ) {
     }
 
@@ -53,12 +53,12 @@ final readonly class AliceYamlFixturesToPhpCommand implements CommandInterface
             // remove YAML file
             unlink($yamlFileInfo->getRealPath());
 
-            $this->symfonyStyle->writeln('[DELETED] ' . $yamlFileInfo->getRelativePathname());
-            $this->symfonyStyle->writeln('[ADDED] ' . $phpFilePath);
-            $this->symfonyStyle->newLine();
+            $this->outputPrinter->writeln('[DELETED] ' . $yamlFileInfo->getRelativePathname());
+            $this->outputPrinter->writeln('[ADDED] ' . $phpFilePath);
+            $this->outputPrinter->newline();
         }
 
-        $this->symfonyStyle->success(
+        $this->outputPrinter->success(
             sprintf('Successfully converted %d Alice YAML fixtures to PHP', count($yamlFileInfos))
         );
 

--- a/src/Command/CheckCommentedCodeCommand.php
+++ b/src/Command/CheckCommentedCodeCommand.php
@@ -6,9 +6,9 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Rector\SwissKnife\Comments\CommentedCodeAnalyzer;
 use Rector\SwissKnife\Finder\PhpFilesFinder;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 final readonly class CheckCommentedCodeCommand implements CommandInterface
 {
@@ -16,7 +16,7 @@ final readonly class CheckCommentedCodeCommand implements CommandInterface
 
     public function __construct(
         private CommentedCodeAnalyzer $commentedCodeAnalyzer,
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
     ) {
     }
 
@@ -32,7 +32,7 @@ final readonly class CheckCommentedCodeCommand implements CommandInterface
         $phpFileInfos = PhpFilesFinder::find($sources, $skipFiles);
 
         $message = sprintf('Analysing %d *.php files', count($phpFileInfos));
-        $this->symfonyStyle->note($message);
+        $this->outputPrinter->yellow($message);
 
         $commentedLinesByFilePaths = [];
         foreach ($phpFileInfos as $phpFileInfo) {
@@ -46,18 +46,18 @@ final readonly class CheckCommentedCodeCommand implements CommandInterface
         }
 
         if ($commentedLinesByFilePaths === []) {
-            $this->symfonyStyle->success('No commented code found');
+            $this->outputPrinter->success('No commented code found');
             return ExitCode::SUCCESS;
         }
 
         foreach ($commentedLinesByFilePaths as $filePath => $commentedLines) {
             foreach ($commentedLines as $commentedLine) {
                 $messageLine = ' * ' . $filePath . ':' . $commentedLine;
-                $this->symfonyStyle->writeln($messageLine);
+                $this->outputPrinter->writeln($messageLine);
             }
         }
 
-        $this->symfonyStyle->error('Errors found');
+        $this->outputPrinter->error('Errors found');
 
         return ExitCode::ERROR;
     }

--- a/src/Command/CheckConflictsCommand.php
+++ b/src/Command/CheckConflictsCommand.php
@@ -6,15 +6,15 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Rector\SwissKnife\Finder\FilesFinder;
 use Rector\SwissKnife\Git\ConflictResolver;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 final readonly class CheckConflictsCommand implements CommandInterface
 {
     public function __construct(
         private ConflictResolver $conflictResolver,
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
     ) {
     }
 
@@ -35,14 +35,14 @@ final readonly class CheckConflictsCommand implements CommandInterface
         $conflictsCountByFilePath = $this->conflictResolver->extractFromFileInfos($filePaths);
         if ($conflictsCountByFilePath === []) {
             $message = sprintf('No conflicts found in %d files', count($fileInfos));
-            $this->symfonyStyle->success($message);
+            $this->outputPrinter->success($message);
 
             return ExitCode::SUCCESS;
         }
 
         foreach ($conflictsCountByFilePath as $file => $conflictCount) {
             $message = sprintf('File "%s" contains %d unresolved conflicts', $file, $conflictCount);
-            $this->symfonyStyle->error($message);
+            $this->outputPrinter->error($message);
         }
 
         return ExitCode::ERROR;

--- a/src/Command/DumpEditorconfigCommand.php
+++ b/src/Command/DumpEditorconfigCommand.php
@@ -6,13 +6,13 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Nette\Utils\FileSystem;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 final readonly class DumpEditorconfigCommand implements CommandInterface
 {
     public function __construct(
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
     ) {
     }
 
@@ -30,14 +30,14 @@ final readonly class DumpEditorconfigCommand implements CommandInterface
     {
         $projectEditorconfigFilePath = getcwd() . '/.editorconfig';
         if (file_exists($projectEditorconfigFilePath)) {
-            $this->symfonyStyle->error('.editorconfig file already exists');
+            $this->outputPrinter->error('.editorconfig file already exists');
 
             return ExitCode::ERROR;
         }
 
         FileSystem::copy(__DIR__ . '/../../templates/.editorconfig', $projectEditorconfigFilePath);
 
-        $this->symfonyStyle->success('.editorconfig file was created');
+        $this->outputPrinter->success('.editorconfig file was created');
 
         return ExitCode::SUCCESS;
     }

--- a/src/Command/FinalizeClassesCommand.php
+++ b/src/Command/FinalizeClassesCommand.php
@@ -6,6 +6,9 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputColorizer;
+use Entropy\Console\Output\OutputPrinter;
+use Entropy\Console\Output\ProgressBar;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use Rector\SwissKnife\Analyzer\NeedsFinalizeAnalyzer;
@@ -15,7 +18,6 @@ use Rector\SwissKnife\Finder\PhpFilesFinder;
 use Rector\SwissKnife\MockedClassResolver;
 use Rector\SwissKnife\ParentClassResolver;
 use Rector\SwissKnife\PhpParser\CachedPhpParser;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 final readonly class FinalizeClassesCommand implements CommandInterface
 {
@@ -25,7 +27,8 @@ final readonly class FinalizeClassesCommand implements CommandInterface
     private const string NEWLINE_CLASS_START_REGEX = '#^(readonly )?class\s#m';
 
     public function __construct(
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
+        private OutputColorizer $outputColorizer,
         private ParentClassResolver $parentClassResolver,
         private EntityClassResolver $entityClassResolver,
         private CachedPhpParser $cachedPhpParser,
@@ -47,23 +50,25 @@ final readonly class FinalizeClassesCommand implements CommandInterface
         array $skipFiles = [],
         bool $noProgress = false
     ): int {
-        $this->symfonyStyle->title('1. Detecting parent and entity classes');
+        $this->outputPrinter->title('1. Detecting parent and entity classes');
 
         $phpFileInfos = PhpFilesFinder::find($paths, $skipFiles);
 
+        $progressBar = null;
         if (! $noProgress) {
             // double to count for both parent and entity resolver
             $stepRatio = $skipMocked ? 3 : 2;
 
-            $this->symfonyStyle->progressStart($stepRatio * count($phpFileInfos));
+            $progressBar = new ProgressBar($this->outputColorizer);
+            $progressBar->start($stepRatio * count($phpFileInfos));
         }
 
-        $progressClosure = function () use ($noProgress): void {
-            if ($noProgress) {
+        $progressClosure = function () use ($noProgress, $progressBar): void {
+            if ($noProgress || !$progressBar instanceof ProgressBar) {
                 return;
             }
 
-            $this->symfonyStyle->progressAdvance();
+            $progressBar->advance();
         };
 
         $parentClassNames = $this->parentClassResolver->resolve($phpFileInfos, $progressClosure);
@@ -71,23 +76,23 @@ final readonly class FinalizeClassesCommand implements CommandInterface
 
         $mockedClassNames = $skipMocked ? $this->mockedClassResolver->resolve($paths, $progressClosure) : [];
 
-        if (! $noProgress) {
-            $this->symfonyStyle->progressFinish();
+        if ($progressBar instanceof ProgressBar) {
+            $progressBar->finish();
         }
 
-        $this->symfonyStyle->writeln(sprintf(
+        $this->outputPrinter->writeln(sprintf(
             'Found %d parent and %d entity classes',
             count($parentClassNames),
             count($entityClassNames)
         ));
 
         if ($skipMocked) {
-            $this->symfonyStyle->writeln(sprintf('Also %d mocked classes', count($mockedClassNames)));
+            $this->outputPrinter->writeln(sprintf('Also %d mocked classes', count($mockedClassNames)));
         }
 
-        $this->symfonyStyle->newLine(1);
+        $this->outputPrinter->newline(1);
 
-        $this->symfonyStyle->title('2. Finalizing safe classes');
+        $this->outputPrinter->title('2. Finalizing safe classes');
 
         $excludedClasses = array_merge($parentClassNames, $entityClassNames, $mockedClassNames);
         $needsFinalizeAnalyzer = new NeedsFinalizeAnalyzer($excludedClasses, $this->cachedPhpParser);
@@ -114,18 +119,18 @@ final readonly class FinalizeClassesCommand implements CommandInterface
         }
 
         if ($finalizedFilePaths === []) {
-            $this->symfonyStyle->success('Nothing to finalize');
+            $this->outputPrinter->success('Nothing to finalize');
             return ExitCode::SUCCESS;
         }
 
-        $this->symfonyStyle->listing($finalizedFilePaths);
+        $this->outputPrinter->listing($finalizedFilePaths);
 
         $countFinalizedClasses = count($finalizedFilePaths);
         $pluralClassText = $countFinalizedClasses === 1 ? 'class' : 'classes';
 
         // to make it fail in CI
         if ($dryRun) {
-            $this->symfonyStyle->error(sprintf(
+            $this->outputPrinter->error(sprintf(
                 '%d %s can be finalized',
                 $countFinalizedClasses,
                 $pluralClassText,
@@ -134,7 +139,7 @@ final readonly class FinalizeClassesCommand implements CommandInterface
             return ExitCode::ERROR;
         }
 
-        $this->symfonyStyle->success(sprintf('%d %s finalized', $countFinalizedClasses, $pluralClassText));
+        $this->outputPrinter->success(sprintf('%d %s finalized', $countFinalizedClasses, $pluralClassText));
 
         return ExitCode::SUCCESS;
     }

--- a/src/Command/FindMultiClassesCommand.php
+++ b/src/Command/FindMultiClassesCommand.php
@@ -6,16 +6,16 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Rector\SwissKnife\FileSystem\PathHelper;
 use Rector\SwissKnife\Finder\MultipleClassInOneFileFinder;
 use Rector\SwissKnife\Finder\PhpFilesFinder;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 final readonly class FindMultiClassesCommand implements CommandInterface
 {
     public function __construct(
         private MultipleClassInOneFileFinder $multipleClassInOneFileFinder,
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
     ) {
     }
 
@@ -31,7 +31,7 @@ final readonly class FindMultiClassesCommand implements CommandInterface
 
         $multipleClassesByFile = $this->multipleClassInOneFileFinder->findInDirectories($sources, $excludePaths);
         if ($multipleClassesByFile === []) {
-            $this->symfonyStyle->success(sprintf('No file with 2+ classes found in %d files', count($phpFileInfos)));
+            $this->outputPrinter->success(sprintf('No file with 2+ classes found in %d files', count($phpFileInfos)));
 
             return ExitCode::SUCCESS;
         }
@@ -41,8 +41,8 @@ final readonly class FindMultiClassesCommand implements CommandInterface
             $relativeFilePath = PathHelper::relativeToCwd($filePath);
 
             $message = sprintf('File "%s" contains %d classes', $relativeFilePath, count($classes));
-            $this->symfonyStyle->section($message);
-            $this->symfonyStyle->listing($classes);
+            $this->outputPrinter->section($message);
+            $this->outputPrinter->listing($classes);
         }
 
         return ExitCode::ERROR;

--- a/src/Command/GenerateSymfonyConfigBuildersCommand.php
+++ b/src/Command/GenerateSymfonyConfigBuildersCommand.php
@@ -6,12 +6,12 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
-use Symfony\Component\Console\Style\SymfonyStyle;
+use Entropy\Console\Output\OutputPrinter;
 
 final readonly class GenerateSymfonyConfigBuildersCommand implements CommandInterface
 {
     public function __construct(
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
     ) {
     }
 
@@ -30,7 +30,7 @@ final readonly class GenerateSymfonyConfigBuildersCommand implements CommandInte
      */
     public function run(): int
     {
-        $this->symfonyStyle->error(
+        $this->outputPrinter->error(
             'This command is deprecated. Symfony 5.3 config builders were deprecated in Symfony 7.4 in favor of the new PHP configuration API. See https://symfony.com/blog/new-in-symfony-7-4-better-php-configuration'
         );
 

--- a/src/Command/GenerateSymfonySmokeTestsCommand.php
+++ b/src/Command/GenerateSymfonySmokeTestsCommand.php
@@ -6,13 +6,13 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
 use Rector\SwissKnife\SmokeTestgen\FileSystem\TestsDirectoryResolver;
 use Rector\SwissKnife\SmokeTestgen\Templating\TemplateDecorator;
 use Rector\SwissKnife\SmokeTestgen\TestTemplateResolver;
 use Rector\SwissKnife\SmokeTestgen\Utils\TestPathResolver;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Webmozart\Assert\Assert;
 
 final readonly class GenerateSymfonySmokeTestsCommand implements CommandInterface
@@ -21,7 +21,7 @@ final readonly class GenerateSymfonySmokeTestsCommand implements CommandInterfac
         private TestsDirectoryResolver $testsDirectoryResolver,
         private TestTemplateResolver $testTemplateResolver,
         private TemplateDecorator $templateDecorator,
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
     ) {
     }
 
@@ -40,24 +40,24 @@ final readonly class GenerateSymfonySmokeTestsCommand implements CommandInterfac
      */
     public function run(): int
     {
-        $this->symfonyStyle->writeln('<fg=green>Resolving directory for smoke tests</>');
+        $this->outputPrinter->writeln('<fg=green>Resolving directory for smoke tests</>');
 
         $smokeTestsDirectory = $this->testsDirectoryResolver->resolveSmokeUnitTestDirectory(getcwd());
-        $this->symfonyStyle->writeln(' * ' . $smokeTestsDirectory);
+        $this->outputPrinter->writeln(' * ' . $smokeTestsDirectory);
 
         $requirePackages = $this->resolveProjectRequiredPackageNames(getcwd());
         $testByPackageSubscribers = $this->testTemplateResolver->matchProjectPackages($requirePackages);
 
         if ($testByPackageSubscribers === []) {
-            $this->symfonyStyle->warning(
+            $this->outputPrinter->warning(
                 'No test templates found for the required packages. Make sure you project uses Composer to manage version and has Symfony/Doctrine packages listed in "require" section'
             );
 
             return ExitCode::ERROR;
         }
 
-        $this->symfonyStyle->newLine();
-        $this->symfonyStyle->writeln(sprintf(
+        $this->outputPrinter->newline();
+        $this->outputPrinter->writeln(sprintf(
             'Found <fg=yellow>%d smoke test%s</> that might come handy',
             count($testByPackageSubscribers),
             count($testByPackageSubscribers) > 1 ? 's' : ''
@@ -69,7 +69,7 @@ final readonly class GenerateSymfonySmokeTestsCommand implements CommandInterfac
             $projectTestFilePath = TestPathResolver::resolve($test, $smokeTestsDirectory);
 
             if (file_exists($projectTestFilePath)) {
-                $this->symfonyStyle->writeln(
+                $this->outputPrinter->writeln(
                     sprintf('File <fg=green>%s</> already exists, skipping', $projectTestFilePath)
                 );
                 continue;
@@ -80,13 +80,13 @@ final readonly class GenerateSymfonySmokeTestsCommand implements CommandInterfac
 
             FileSystem::write($projectTestFilePath, $templateContents);
 
-            $this->symfonyStyle->writeln(sprintf('Generated new test file %s', $projectTestFilePath));
+            $this->outputPrinter->writeln(sprintf('Generated new test file %s', $projectTestFilePath));
 
             ++$generatedTestCount;
         }
 
         if ($generatedTestCount === 0) {
-            $this->symfonyStyle->success('No new test files were generated. All required tests already exist.');
+            $this->outputPrinter->success('No new test files were generated. All required tests already exist.');
             return ExitCode::SUCCESS;
         }
 
@@ -101,14 +101,14 @@ final readonly class GenerateSymfonySmokeTestsCommand implements CommandInterfac
             FileSystem::write($projectTestCaseFilePath, $templateContents);
         }
 
-        $this->symfonyStyle->success(sprintf(
+        $this->outputPrinter->success(sprintf(
             'Generated %d new test file%s in "%s"',
             $generatedTestCount,
             $generatedTestCount > 1 ? 's' : '',
             $smokeTestsDirectory
         ));
 
-        $this->symfonyStyle->newLine();
+        $this->outputPrinter->newline();
 
         return ExitCode::SUCCESS;
     }

--- a/src/Command/NamespaceToPSR4Command.php
+++ b/src/Command/NamespaceToPSR4Command.php
@@ -6,16 +6,16 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
 final readonly class NamespaceToPSR4Command implements CommandInterface
 {
     public function __construct(
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
     ) {
     }
 
@@ -45,7 +45,7 @@ final readonly class NamespaceToPSR4Command implements CommandInterface
             }
 
             // 2. incorrect namespace found
-            $this->symfonyStyle->note(sprintf(
+            $this->outputPrinter->yellow(sprintf(
                 'File "%s"%s fixed to expected namespace "%s"',
                 $fileInfo->getRelativePathname(),
                 PHP_EOL,
@@ -66,9 +66,9 @@ final readonly class NamespaceToPSR4Command implements CommandInterface
         }
 
         if ($changedFilesCount === 0) {
-            $this->symfonyStyle->success(sprintf('All %d files have correct namespace', count($fileInfos)));
+            $this->outputPrinter->success(sprintf('All %d files have correct namespace', count($fileInfos)));
         } else {
-            $this->symfonyStyle->success(sprintf('Fixed %d files', $changedFilesCount));
+            $this->outputPrinter->success(sprintf('Fixed %d files', $changedFilesCount));
         }
 
         return ExitCode::SUCCESS;

--- a/src/Command/PrettyJsonCommand.php
+++ b/src/Command/PrettyJsonCommand.php
@@ -6,16 +6,16 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Json;
 use Rector\SwissKnife\FileSystem\JsonAnalyzer;
 use Rector\SwissKnife\Finder\FilesFinder;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 final readonly class PrettyJsonCommand implements CommandInterface
 {
     public function __construct(
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
         private JsonAnalyzer $jsonAnalyzer,
     ) {
     }
@@ -31,12 +31,12 @@ final readonly class PrettyJsonCommand implements CommandInterface
         $jsonFileInfos = FilesFinder::findJsonFiles($sources);
 
         if ($jsonFileInfos === []) {
-            $this->symfonyStyle->error('No *.json files found');
+            $this->outputPrinter->error('No *.json files found');
             return ExitCode::ERROR;
         }
 
         $message = sprintf('Analysing %d *.json files', count($jsonFileInfos));
-        $this->symfonyStyle->note($message);
+        $this->outputPrinter->yellow($message);
 
         $printedFilePaths = [];
 
@@ -44,7 +44,7 @@ final readonly class PrettyJsonCommand implements CommandInterface
         foreach ($jsonFileInfos as $jsonFileInfo) {
             $jsonContent = FileSystem::read($jsonFileInfo->getRealPath());
             if ($this->jsonAnalyzer->isPrettyPrinted($jsonContent)) {
-                $this->symfonyStyle->writeln(
+                $this->outputPrinter->writeln(
                     sprintf('File "%s" is already pretty', $jsonFileInfo->getRelativePathname())
                 );
                 continue;
@@ -69,8 +69,8 @@ final readonly class PrettyJsonCommand implements CommandInterface
             $dryRun ? 'would be changed' : 'changed'
         );
 
-        $this->symfonyStyle->success($successMessage);
-        $this->symfonyStyle->listing($printedFilePaths);
+        $this->outputPrinter->success($successMessage);
+        $this->outputPrinter->listing($printedFilePaths);
 
         return ExitCode::SUCCESS;
     }

--- a/src/Command/PrivatizeConstantsCommand.php
+++ b/src/Command/PrivatizeConstantsCommand.php
@@ -6,6 +6,9 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputColorizer;
+use Entropy\Console\Output\OutputPrinter;
+use Entropy\Console\Output\ProgressBar;
 use Nette\Utils\FileSystem;
 use Nette\Utils\Strings;
 use Rector\SwissKnife\Contract\ClassConstantFetchInterface;
@@ -17,13 +20,13 @@ use Rector\SwissKnife\ValueObject\ClassConstant;
 use Rector\SwissKnife\ValueObject\ClassConstantFetch\CurrentClassConstantFetch;
 use Rector\SwissKnife\ValueObject\VisibilityChangeStats;
 use Rector\SwissKnife\YAML\YamlConfigConstantExtractor;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\SplFileInfo;
 
 final readonly class PrivatizeConstantsCommand implements CommandInterface
 {
     public function __construct(
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
+        private OutputColorizer $outputColorizer,
         private ClassConstantFetchFinder $classConstantFetchFinder,
         private ClassConstFinder $classConstFinder,
         private TwigTemplateConstantExtractor $twigTemplateConstantExtractor,
@@ -56,14 +59,16 @@ final readonly class PrivatizeConstantsCommand implements CommandInterface
     ): int {
         $phpFileInfos = PhpFilesFinder::find($sources, $excludedPaths);
         if ($phpFileInfos === []) {
-            $this->symfonyStyle->warning('No PHP files found in provided paths');
+            $this->outputPrinter->warning('No PHP files found in provided paths');
 
             return ExitCode::SUCCESS;
         }
 
-        $this->symfonyStyle->title('Finding class const fetches...');
+        $this->outputPrinter->title('Finding class const fetches...');
 
-        $progressBar = $this->symfonyStyle->createProgressBar(count($phpFileInfos));
+        $progressBar = new ProgressBar($this->outputColorizer);
+        $progressBar->start(count($phpFileInfos));
+
         $phpClassConstantFetches = $this->classConstantFetchFinder->find($phpFileInfos, $progressBar, $isDebug);
 
         // find usage in twig files
@@ -76,14 +81,16 @@ final readonly class PrivatizeConstantsCommand implements CommandInterface
             $yamlClassConstantFetches
         );
 
-        $this->symfonyStyle->newLine(2);
-        $this->symfonyStyle->success(sprintf('Found %d class constant fetches', count($classConstantFetches)));
-        $this->symfonyStyle->success(sprintf('Found %d constants in Twig templates', count($twigClassConstantFetches)));
-        $this->symfonyStyle->success(sprintf('Found %d constants in YAML configs', count($yamlClassConstantFetches)));
+        $this->outputPrinter->newline(2);
+        $this->outputPrinter->success(sprintf('Found %d class constant fetches', count($classConstantFetches)));
+        $this->outputPrinter->success(
+            sprintf('Found %d constants in Twig templates', count($twigClassConstantFetches))
+        );
+        $this->outputPrinter->success(sprintf('Found %d constants in YAML configs', count($yamlClassConstantFetches)));
 
-        $this->symfonyStyle->newLine(2);
+        $this->outputPrinter->newline(2);
 
-        $this->symfonyStyle->title('Changing class constant visibility based on use...');
+        $this->outputPrinter->title('Changing class constant visibility based on use...');
 
         $visibilityChangeStats = new VisibilityChangeStats();
 
@@ -94,23 +101,23 @@ final readonly class PrivatizeConstantsCommand implements CommandInterface
         }
 
         if (! $visibilityChangeStats->hasAnyChange()) {
-            $this->symfonyStyle->warning('No constants were privatized');
+            $this->outputPrinter->warning('No constants were privatized');
 
             return ExitCode::SUCCESS;
         }
 
-        $this->symfonyStyle->newLine(2);
+        $this->outputPrinter->newline(2);
 
         // to make it fail in CI
         if ($dryRun) {
-            $this->symfonyStyle->error(
+            $this->outputPrinter->error(
                 sprintf('%d constants can be privatized', $visibilityChangeStats->getPrivateCount())
             );
 
             return ExitCode::ERROR;
         }
 
-        $this->symfonyStyle->success(
+        $this->outputPrinter->success(
             sprintf('Totally %d constants were made private', $visibilityChangeStats->getPrivateCount())
         );
 
@@ -141,7 +148,7 @@ final readonly class PrivatizeConstantsCommand implements CommandInterface
             $visibilityChangeStats->countPrivate();
 
             if ($dryRun) {
-                $this->symfonyStyle->writeln(
+                $this->outputPrinter->writeln(
                     sprintf('Constant "%s" could be changed to private', $classConstant->getConstantName())
                 );
                 continue;
@@ -155,7 +162,7 @@ final readonly class PrivatizeConstantsCommand implements CommandInterface
             );
             FileSystem::write($phpFileInfo->getRealPath(), $changedFileContents, null);
 
-            $this->symfonyStyle->writeln(
+            $this->outputPrinter->writeln(
                 sprintf('Constant "%s" changed to private', $classConstant->getConstantName())
             );
         }

--- a/src/Command/SearchRegexCommand.php
+++ b/src/Command/SearchRegexCommand.php
@@ -6,15 +6,18 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputColorizer;
+use Entropy\Console\Output\OutputPrinter;
+use Entropy\Console\Output\ProgressBar;
 use Nette\Utils\Strings;
 use Rector\SwissKnife\Finder\PhpFilesFinder;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Webmozart\Assert\Assert;
 
 final readonly class SearchRegexCommand implements CommandInterface
 {
     public function __construct(
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
+        private OutputColorizer $outputColorizer,
     ) {
     }
 
@@ -35,15 +38,16 @@ final readonly class SearchRegexCommand implements CommandInterface
         $phpFileInfos = PhpFilesFinder::find([$projectDirectory]);
 
         $message = sprintf('Going through %d *.php files', count($phpFileInfos));
-        $this->symfonyStyle->writeln($message);
+        $this->outputPrinter->writeln($message);
 
-        $this->symfonyStyle->writeln('Searching for regex: ' . $regex);
-        $this->symfonyStyle->newLine();
+        $this->outputPrinter->writeln('Searching for regex: ' . $regex);
+        $this->outputPrinter->newline();
 
         $foundCasesCount = 0;
         $markedFiles = [];
 
-        $progressBar = $this->symfonyStyle->createProgressBar(count($phpFileInfos));
+        $progressBar = new ProgressBar($this->outputColorizer);
+        $progressBar->start(count($phpFileInfos));
 
         foreach ($phpFileInfos as $phpFileInfo) {
             $matches = Strings::matchAll($phpFileInfo->getContents(), $regex);
@@ -59,15 +63,15 @@ final readonly class SearchRegexCommand implements CommandInterface
         }
 
         $progressBar->finish();
-        $this->symfonyStyle->newLine(2);
+        $this->outputPrinter->newline(2);
 
         ksort($markedFiles);
         foreach ($markedFiles as $filePath => $count) {
-            $this->symfonyStyle->writeln(sprintf(' * %s: %d', $filePath, $count));
+            $this->outputPrinter->writeln(sprintf(' * %s: %d', $filePath, $count));
         }
 
-        $this->symfonyStyle->newLine(2);
-        $this->symfonyStyle->success(sprintf('Found %d cases in %d files', $foundCasesCount, count($markedFiles)));
+        $this->outputPrinter->newline(2);
+        $this->outputPrinter->success(sprintf('Found %d cases in %d files', $foundCasesCount, count($markedFiles)));
 
         return ExitCode::SUCCESS;
     }

--- a/src/Command/SplitSymfonyConfigToPerPackageCommand.php
+++ b/src/Command/SplitSymfonyConfigToPerPackageCommand.php
@@ -6,6 +6,7 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Nette\Utils\FileSystem;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
@@ -18,7 +19,6 @@ use Rector\SwissKnife\Exception\ShouldNotHappenException;
 use Rector\SwissKnife\PhpParser\NodeFactory\SplitConfigClosureFactory;
 use Rector\SwissKnife\PhpParser\NodeVisitor\AddImportConfigMethodCallNodeVisitor;
 use Rector\SwissKnife\PhpParser\NodeVisitor\ExtractSymfonyExtensionCallNodeVisitor;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Webmozart\Assert\Assert;
 
 final readonly class SplitSymfonyConfigToPerPackageCommand implements CommandInterface
@@ -26,7 +26,7 @@ final readonly class SplitSymfonyConfigToPerPackageCommand implements CommandInt
     private Standard $printerStandard;
 
     public function __construct(
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
         private SplitConfigClosureFactory $splitConfigClosureFactory,
     ) {
         $this->printerStandard = new Standard();
@@ -48,7 +48,7 @@ final readonly class SplitSymfonyConfigToPerPackageCommand implements CommandInt
         $symfonyExtensionMethodCalls = $this->extractSymfonyExtensionMethodCalls($stmts);
 
         if ($symfonyExtensionMethodCalls === []) {
-            $this->symfonyStyle->warning('No extension() method calls found');
+            $this->outputPrinter->warning('No extension() method calls found');
 
             return ExitCode::SUCCESS;
         }

--- a/src/Command/SpotLazyTraitsCommand.php
+++ b/src/Command/SpotLazyTraitsCommand.php
@@ -6,13 +6,13 @@ namespace Rector\SwissKnife\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Rector\SwissKnife\Traits\TraitSpotter;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 final readonly class SpotLazyTraitsCommand implements CommandInterface
 {
     public function __construct(
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
         private TraitSpotter $traitSpotter,
     ) {
     }
@@ -24,32 +24,32 @@ final readonly class SpotLazyTraitsCommand implements CommandInterface
      */
     public function run(array $sources, int $maxUsed = 2): int
     {
-        $this->symfonyStyle->title('Looking for trait definitions');
+        $this->outputPrinter->title('Looking for trait definitions');
         $traitSpottingResult = $this->traitSpotter->analyse($sources);
 
         if ($traitSpottingResult->getTraitCount() === 0) {
-            $this->symfonyStyle->success('No traits were found in your project, nothing to worry about');
+            $this->outputPrinter->success('No traits were found in your project, nothing to worry about');
 
             return ExitCode::SUCCESS;
         }
 
-        $this->symfonyStyle->writeln(
+        $this->outputPrinter->writeln(
             sprintf(
                 'Found %d trait%s in the whole project',
                 $traitSpottingResult->getTraitCount(),
                 $traitSpottingResult->getTraitCount() === 1 ? '' : 's'
             )
         );
-        $this->symfonyStyle->listing($traitSpottingResult->getTraitFilePaths());
+        $this->outputPrinter->listing($traitSpottingResult->getTraitFilePaths());
 
-        $this->symfonyStyle->newLine();
+        $this->outputPrinter->newline();
 
-        $this->symfonyStyle->title(sprintf('Looking for traits used less than %d-times', $maxUsed));
+        $this->outputPrinter->title(sprintf('Looking for traits used less than %d-times', $maxUsed));
 
         $leastUsedTraitsMetadatas = $traitSpottingResult->getTraitMaximumUsedTimes($maxUsed);
 
         foreach ($leastUsedTraitsMetadatas as $leastUsedTraitMetadata) {
-            $this->symfonyStyle->writeln(sprintf(
+            $this->outputPrinter->writeln(sprintf(
                 'Trait "%s" (%d lines) is used only in %d file%s',
                 $leastUsedTraitMetadata->getShortTraitName(),
                 $leastUsedTraitMetadata->getLineCount(),
@@ -57,11 +57,11 @@ final readonly class SpotLazyTraitsCommand implements CommandInterface
                 $leastUsedTraitMetadata->getUsedInCount() === 1 ? '' : 's'
             ));
 
-            $this->symfonyStyle->listing($leastUsedTraitMetadata->getUsedIn());
-            $this->symfonyStyle->newLine();
+            $this->outputPrinter->listing($leastUsedTraitMetadata->getUsedIn());
+            $this->outputPrinter->newline();
         }
 
-        $this->symfonyStyle->warning(sprintf(
+        $this->outputPrinter->warning(sprintf(
             'Inline these traits or refactor them to a service if meaningful.%sChange "--max-used" to different number to get more result',
             PHP_EOL
         ));

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -7,9 +7,6 @@ namespace Rector\SwissKnife\DependencyInjection;
 use Entropy\Container\Container;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
  * @api used in tests
@@ -26,11 +23,6 @@ final class ContainerFactory
             $phpParserFactory = new ParserFactory();
             return $phpParserFactory->createForNewestSupportedVersion();
         });
-
-        $container->service(
-            SymfonyStyle::class,
-            static fn (): SymfonyStyle => new SymfonyStyle(new ArrayInput([]), new ConsoleOutput())
-        );
 
         return $container;
     }

--- a/src/PhpParser/Finder/ClassConstantFetchFinder.php
+++ b/src/PhpParser/Finder/ClassConstantFetchFinder.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 namespace Rector\SwissKnife\PhpParser\Finder;
 
+use Entropy\Console\Output\OutputPrinter;
+use Entropy\Console\Output\ProgressBar;
 use Rector\SwissKnife\Contract\ClassConstantFetchInterface;
 use Rector\SwissKnife\Exception\NotImplementedYetException;
 use Rector\SwissKnife\Exception\ShouldNotHappenException;
 use Rector\SwissKnife\PhpParser\CachedPhpParser;
 use Rector\SwissKnife\PhpParser\NodeTraverserFactory;
 use Rector\SwissKnife\PhpParser\NodeVisitor\FindClassConstFetchNodeVisitor;
-use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
@@ -21,7 +21,7 @@ final readonly class ClassConstantFetchFinder
 {
     public function __construct(
         private CachedPhpParser $cachedPhpParser,
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
     ) {
     }
 
@@ -36,7 +36,7 @@ final readonly class ClassConstantFetchFinder
 
         foreach ($phpFileInfos as $phpFileInfo) {
             if ($isDebug) {
-                $this->symfonyStyle->writeln('Processing ' . $phpFileInfo->getRealPath());
+                $this->outputPrinter->writeln('Processing ' . $phpFileInfo->getRealPath());
             }
 
             $fileStmts = $this->cachedPhpParser->parseFile($phpFileInfo->getRealPath());
@@ -46,7 +46,7 @@ final readonly class ClassConstantFetchFinder
             } catch (ShouldNotHappenException|NotImplementedYetException $exception) {
                 // render debug contents if verbose
                 if ($isDebug) {
-                    $this->symfonyStyle->error($exception->getMessage());
+                    $this->outputPrinter->error($exception->getMessage());
                 }
             }
 

--- a/src/Testing/Command/DetectUnitTestsCommand.php
+++ b/src/Testing/Command/DetectUnitTestsCommand.php
@@ -6,10 +6,10 @@ namespace Rector\SwissKnife\Testing\Command;
 
 use Entropy\Console\Contract\CommandInterface;
 use Entropy\Console\Enum\ExitCode;
+use Entropy\Console\Output\OutputPrinter;
 use Nette\Utils\FileSystem;
 use Rector\SwissKnife\Testing\Printer\PHPUnitXmlPrinter;
 use Rector\SwissKnife\Testing\UnitTestFilePathsFinder;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Webmozart\Assert\Assert;
 
 final readonly class DetectUnitTestsCommand implements CommandInterface
@@ -18,7 +18,7 @@ final readonly class DetectUnitTestsCommand implements CommandInterface
 
     public function __construct(
         private PHPUnitXmlPrinter $phpunitXmlPrinter,
-        private SymfonyStyle $symfonyStyle,
+        private OutputPrinter $outputPrinter,
         private UnitTestFilePathsFinder $unitTestFilePathsFinder,
     ) {
     }
@@ -33,7 +33,7 @@ final readonly class DetectUnitTestsCommand implements CommandInterface
         $unitTestCasesClassesToFilePaths = $this->unitTestFilePathsFinder->findInDirectories($sources);
 
         if ($unitTestCasesClassesToFilePaths === []) {
-            $this->symfonyStyle->note('No unit tests found in provided paths');
+            $this->outputPrinter->yellow('No unit tests found in provided paths');
 
             return ExitCode::SUCCESS;
         }
@@ -48,7 +48,7 @@ final readonly class DetectUnitTestsCommand implements CommandInterface
             self::OUTPUT_FILENAME,
         );
 
-        $this->symfonyStyle->success($successMessage);
+        $this->outputPrinter->success($successMessage);
 
         return ExitCode::SUCCESS;
     }

--- a/tests/PhpParser/Finder/ClassConstantFetchFinder/ClassConstantFetchFinderTest.php
+++ b/tests/PhpParser/Finder/ClassConstantFetchFinder/ClassConstantFetchFinderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rector\SwissKnife\Tests\PhpParser\Finder\ClassConstantFetchFinder;
 
+use Entropy\Console\Output\OutputColorizer;
+use Entropy\Console\Output\ProgressBar;
 use Override;
 use Rector\SwissKnife\Contract\ClassConstantFetchInterface;
 use Rector\SwissKnife\Finder\PhpFilesFinder;
@@ -12,8 +14,6 @@ use Rector\SwissKnife\Tests\AbstractTestCase;
 use Rector\SwissKnife\ValueObject\ClassConstantFetch\CurrentClassConstantFetch;
 use Rector\SwissKnife\ValueObject\ClassConstantFetch\ExternalClassAccessConstantFetch;
 use RuntimeException;
-use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Output\NullOutput;
 
 final class ClassConstantFetchFinderTest extends AbstractTestCase
 {
@@ -53,7 +53,7 @@ final class ClassConstantFetchFinderTest extends AbstractTestCase
         );
 
         $directory = __DIR__ . '/Fixture/Error';
-        $progressBar = new ProgressBar(new NullOutput());
+        $progressBar = new ProgressBar(new OutputColorizer());
         $fileInfos = PhpFilesFinder::find([$directory]);
         $this->classConstantFetchFinder->find($fileInfos, $progressBar, false);
     }
@@ -63,7 +63,7 @@ final class ClassConstantFetchFinderTest extends AbstractTestCase
      */
     private function findInDirectory(string $directory): array
     {
-        $progressBar = new ProgressBar(new NullOutput());
+        $progressBar = new ProgressBar(new OutputColorizer());
         $fileInfos = PhpFilesFinder::find([$directory]);
 
         return $this->classConstantFetchFinder->find($fileInfos, $progressBar, false);


### PR DESCRIPTION
Fixes #128

## Summary

Resolves the Composer dependency conflict reported in #128 by removing the direct `symfony/console` requirement and adopting Entropy as the console layer.

Projects using Symfony 8 (e.g. `symfony/yaml ^8.1`) could not install `rector/swiss-knife` because the package required `symfony/console ^6.4.24`, which conflicts with Symfony 8 components. This PR fixes that root cause instead of widening the `symfony/console` constraint (see maintainer feedback on #129).

## What changed

- Remove `symfony/console` from `composer.json`
- Bump `entropy/entropy` to `^0.4.0`
- Replace `SymfonyStyle` with `Entropy\Console\Output\OutputPrinter` in CLI commands and `ClassConstantFetchFinder`
- Replace Symfony `ProgressBar` with `Entropy\Console\Output\ProgressBar` where needed
- Remove manual `SymfonyStyle` registration from `ContainerFactory`

## Test plan

- [x] `composer validate`
- [x] `vendor/bin/phpunit`
- [x] `vendor/bin/phpstan analyse`
- [x] `vendor/bin/ecs check`
- [x] `vendor/bin/composer-dependency-analyser`
- [x] `bin/swiss-knife --help`
- [x] No direct `Symfony\Component\Console` usage in `src`, `tests`, `bin`, `config`